### PR TITLE
Lesson 2 - Add client- and server-caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Lesson - 1
+Lesson - 2

--- a/gb-demo-app-2/apps/api/src/app/news/news.controller.ts
+++ b/gb-demo-app-2/apps/api/src/app/news/news.controller.ts
@@ -13,6 +13,7 @@ export class CreateNewsDto {
 @Controller('news')
 export class NewsController {
   @Get()
+  @Header('Cache-Control', 'max-age=60')
   async getNews() {
     return new Promise(resolve => {
       const news = Object.keys([...Array(20)])

--- a/gb-demo-app-2/apps/web/src/app/news/news.tsx
+++ b/gb-demo-app-2/apps/web/src/app/news/news.tsx
@@ -1,5 +1,5 @@
 import './news.module.scss';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 /* eslint-disable-next-line */
 export interface NewsProps {}
@@ -42,4 +42,4 @@ export function News(props: NewsProps) {
   );
 }
 
-export default News;
+export default React.memo(News);


### PR DESCRIPTION
Практическое задание к уроку № 2 выполнено в полном объеме:
1) в репозиторий добавлен учебный проект - gb-demo-app-2;
2) на стороне сервера к GET запросу добавлен заголовок Cache-Control с временем фиксации ответа 60 сек. Повторное выполнение операции формирования массива новостей не происходит;
3) на стороне клиента компонент News довавлен в HOC React.memo. При навигации на клиенте через меню повторная отрисовка новостей не происходит. Запрос новостей на сервер не выполняется, поэтому необходимость повторной отрисовки компонена отсутствует.